### PR TITLE
Removed boolean fields from @Config interface

### DIFF
--- a/src/main/java/com/joss/conductor/mobile/Config.java
+++ b/src/main/java/com/joss/conductor/mobile/Config.java
@@ -21,12 +21,12 @@ public @interface Config {
     String language() default "";
     String locale() default "";
     String orientation() default "";
-    boolean autoWebView()  default false;
-    boolean noReset()  default false;
-    boolean fullReset() default false;
-    boolean autoAcceptAlerts() default false;
     String hub() default "";
     int timeout() default 5;
     int retries() default 5;
-    boolean screenshotsOnFail() default false;
+//    boolean screenshotsOnFail() default false;
+//    boolean autoWebView()  default false;
+//    boolean noReset()  default false;
+//    boolean fullReset() default false;
+//    boolean autoAcceptAlerts() default false;
 }

--- a/src/main/java/com/joss/conductor/mobile/LocomotiveConfig.java
+++ b/src/main/java/com/joss/conductor/mobile/LocomotiveConfig.java
@@ -97,25 +97,21 @@ public class LocomotiveConfig implements Config {
 
     public boolean autoWebView() {
         return getBooleanValue(Constants.DEFAULT_PROPERTY_AUTO_WEBVIEW,
-                testConfig == null ? null : testConfig.autoWebView(),
                 Constants.JVM_CONDUCTOR_AUTO_WEBVIEW);
     }
 
     public boolean noReset() {
         return getBooleanValue(Constants.DEFAULT_PROPERTY_NO_RESET,
-                testConfig == null ? null : testConfig.noReset(),
                 Constants.JVM_CONDUCTOR_NO_RESET);
     }
 
     public boolean fullReset() {
         return getBooleanValue(Constants.DEFAULT_PROPERTY_FULL_RESET,
-                testConfig == null ? null : testConfig.fullReset(),
                 Constants.JVM_CONDUCTOR_FULL_RESET);
     }
 
     public boolean autoAcceptAlerts() {
         return getBooleanValue(Constants.DEFAULT_PROPERTY_AUTO_ACCEPT_ALERTS,
-                testConfig == null ? null : testConfig.autoAcceptAlerts(),
                 Constants.JVM_CONDUCTOR_AUTO_ACCEPT_ALERTS);
     }
 
@@ -141,7 +137,6 @@ public class LocomotiveConfig implements Config {
 
     public boolean screenshotsOnFail() {
         return getBooleanValue(Constants.DEFAULT_PROPERTY_SCREENSHOTS_ON_FAIL,
-                testConfig == null ? null : testConfig.screenshotsOnFail(),
                 Constants.JVM_CONDUCTOR_SCREENSHOTS_ON_FAIL);
     }
 
@@ -183,16 +178,13 @@ public class LocomotiveConfig implements Config {
         return value;
     }
 
-    private boolean getBooleanValue(String defaultPropertyKey, Boolean testConfigValue, String jvmParamKey) {
+    private boolean getBooleanValue(String defaultPropertyKey, String jvmParamKey) {
         boolean value = false;
         String defaultValue = getProperty(defaultPropertyKey, Boolean.FALSE.toString());
         String jvmValue = JvmUtil.getJvmProperty(jvmParamKey);
 
         if(defaultValue != null && !StringUtils.isEmpty(defaultValue)) {
             value = Boolean.valueOf(defaultValue);
-        }
-        if(testConfigValue != null) {
-            value = testConfigValue;
         }
         if(jvmValue != null && !StringUtils.isEmpty(jvmValue)) {
             value = Boolean.valueOf(jvmValue);

--- a/src/test/java/com/joss/conductor/mobile/LocomotiveConfigTest.java
+++ b/src/test/java/com/joss/conductor/mobile/LocomotiveConfigTest.java
@@ -33,9 +33,7 @@ public class LocomotiveConfigTest {
         testConfig = mock(Config.class);
         when(testConfig.platformName()).thenReturn(Platform.IOS);
         when(testConfig.appPackageName()).thenReturn("com.joss.conductor.mobile.test.andoridConfig");
-        when(testConfig.autoWebView()).thenReturn(false);
         when(testConfig.timeout()).thenReturn(10);
-        when(testConfig.autoAcceptAlerts()).thenReturn(true);
     }
 
     @After
@@ -110,21 +108,6 @@ public class LocomotiveConfigTest {
     @Test
     public void test_default_boolean_properties() {
         LocomotiveConfig config = new LocomotiveConfig(null, defaultProperties);
-        Assertions.assertThat(config.autoWebView())
-                .isTrue();
-    }
-
-    @Test
-    public void test_config_override_default_boolean_properties() {
-        LocomotiveConfig config = new LocomotiveConfig(testConfig, defaultProperties);
-        Assertions.assertThat(config.autoWebView())
-                .isFalse();
-    }
-
-    @Test
-    public void test_jvm_overrides_test_config_boolean_properties() {
-        System.setProperty(Constants.JVM_CONDUCTOR_AUTO_WEBVIEW, Boolean.TRUE.toString());
-        LocomotiveConfig config = new LocomotiveConfig(testConfig, null);
         Assertions.assertThat(config.autoWebView())
                 .isTrue();
     }


### PR DESCRIPTION
I removed boolean fields from the @Config interface because of the way
default boolean values work. An empty boolean @Config fields would
override a default property.